### PR TITLE
Fix dtypes as input.array.dtype for tests to pass.

### DIFF
--- a/e3nn_jax/_src/linear.py
+++ b/e3nn_jax/_src/linear.py
@@ -257,6 +257,7 @@ def linear_mixed(
         )
         for ins in lin.instructions
     ]  # List of shape (d, *path_shape)
+    weights = weights.astype(input.array.dtype)
     w = [
         jnp.sqrt(alpha) ** gradient_normalization * jax.lax.dot_general(weights, wi, (((weights.ndim - 1,), (0,)), ((), ())))
         for wi in w
@@ -296,6 +297,7 @@ def linear_mixed_per_channel(
         )
         for ins in lin.instructions
     ]  # List of shape (d, num_channels, *path_shape)
+    weights = weights.astype(input.array.dtype)
     w = [
         jnp.sqrt(alpha) ** gradient_normalization * jax.lax.dot_general(weights, wi, (((weights.ndim - 1,), (0,)), ((), ())))
         for wi in w

--- a/e3nn_jax/experimental/voxel_convolution.py
+++ b/e3nn_jax/experimental/voxel_convolution.py
@@ -187,7 +187,7 @@ class Convolution(hk.Module):
             irreps_out,
             lax.conv_general_dilated(
                 lhs=input.array,
-                rhs=self.kernel(input.irreps, irreps_out),
+                rhs=self.kernel(input.irreps, irreps_out).astype(input.array.dtype),
                 window_strides=(1, 1, 1),
                 padding=self.padding,
                 dimension_numbers=("NXYZC", "XYZIO", "NXYZC"),


### PR DESCRIPTION
Fixes dtype errors that were failing tests.