### PR TITLE
IrrepsArray more jax pytree and jax transform safe

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - **[BREAKING]** `e3nn.utils.assert_equivariant` has the same signature as `e3nn.utils.equivariance_test`
+- **[BREAKING]** Move `as_irreps_array`, `zeros` and `zeros_like` from `e3nn.IrrepsArray` to `e3nn`
 
 ## [0.18.0] - 2023-06-19
 ### Changed

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -20,4 +20,4 @@ Prefer functions to classes. Implement as a class...
 - When the operation contains parameters (`hk.Module`), this all to create an instance and use it multiple times with the same parameters.
 - When the input format has to be determined before feeding the data. (It is the case of `FunctionalTensorProduct`)
 
-If possible, decorate the function with `e3nn_jax.util.no_data.overload_for_irreps_without_data` to allow the function to determine the output `Irreps` without providing input data.
+If possible, decorate the function with `e3nn_jax.utils.no_data.overload_for_irreps_without_data` to allow the function to determine the output `Irreps` without providing input data.

--- a/docs/api/irreps_array.rst
+++ b/docs/api/irreps_array.rst
@@ -5,6 +5,9 @@ IrrepsArray
     :members:
 
 
+.. autofunction:: e3nn_jax.from_chunks
+
+
 .. autofunction:: e3nn_jax.as_irreps_array
 
 

--- a/docs/api/irreps_array.rst
+++ b/docs/api/irreps_array.rst
@@ -5,6 +5,15 @@ IrrepsArray
     :members:
 
 
+.. autofunction:: e3nn_jax.as_irreps_array
+
+
+.. autofunction:: e3nn_jax.zeros
+
+
+.. autofunction:: e3nn_jax.zeros_like
+
+
 .. autofunction:: e3nn_jax.concatenate
 
 

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -1,11 +1,8 @@
 Utils
 =====
 
-.. autoclass:: e3nn_jax.utils.equivariance_test
-    :members:
+.. autofunction:: e3nn_jax.utils.equivariance_test
 
-.. autoclass:: e3nn_jax.utils.assert_equivariant
-    :members:
+.. autofunction:: e3nn_jax.utils.assert_equivariant
 
-.. autoclass:: e3nn_jax.utils.assert_output_dtype_matches_input_dtype
-    :members:
+.. autofunction:: e3nn_jax.utils.assert_output_dtype_matches_input_dtype

--- a/e3nn_jax/__init__.py
+++ b/e3nn_jax/__init__.py
@@ -53,6 +53,7 @@ from e3nn_jax._src.so3 import clebsch_gordan, generators
 from e3nn_jax._src.irreps import Irrep, MulIrrep, Irreps
 from e3nn_jax._src.irreps_array import IrrepsArray
 from e3nn_jax._src.basic import (
+    from_chunks,
     as_irreps_array,
     zeros,
     zeros_like,
@@ -169,6 +170,7 @@ __all__ = [
     "MulIrrep",  # not in docs
     "Irreps",
     "IrrepsArray",
+    "from_chunks",
     "as_irreps_array",
     "zeros",
     "zeros_like",

--- a/e3nn_jax/__init__.py
+++ b/e3nn_jax/__init__.py
@@ -52,7 +52,18 @@ from e3nn_jax._src.su2 import su2_clebsch_gordan, su2_generators
 from e3nn_jax._src.so3 import clebsch_gordan, generators
 from e3nn_jax._src.irreps import Irrep, MulIrrep, Irreps
 from e3nn_jax._src.irreps_array import IrrepsArray
-from e3nn_jax._src.basic import concatenate, stack, mean, norm, normal, dot, cross
+from e3nn_jax._src.basic import (
+    as_irreps_array,
+    zeros,
+    zeros_like,
+    concatenate,
+    stack,
+    mean,
+    norm,
+    normal,
+    dot,
+    cross,
+)
 from e3nn_jax._src.basic import sum_ as sum
 from e3nn_jax._src.spherical_harmonics import spherical_harmonics, sh, legendre
 from e3nn_jax._src.radial import (
@@ -158,6 +169,9 @@ __all__ = [
     "MulIrrep",  # not in docs
     "Irreps",
     "IrrepsArray",
+    "as_irreps_array",
+    "zeros",
+    "zeros_like",
     "concatenate",
     "stack",
     "mean",

--- a/e3nn_jax/_src/activation.py
+++ b/e3nn_jax/_src/activation.py
@@ -135,7 +135,7 @@ def scalar_activation(
     chunks = []
 
     irreps_out = []
-    for (mul, (l_in, p_in)), x, act in zip(input.irreps, input.list, acts):
+    for (mul, (l_in, p_in)), x, act in zip(input.irreps, input.chunks, acts):
         if act is not None:
             if l_in != 0:
                 raise ValueError(
@@ -212,7 +212,7 @@ def norm_activation(
 
     list = []
 
-    for x, act in zip(input.list, acts):
+    for x, act in zip(input.chunks, acts):
         if act is None:
             list.append(x)
             continue

--- a/e3nn_jax/_src/activation.py
+++ b/e3nn_jax/_src/activation.py
@@ -121,7 +121,7 @@ def scalar_activation(
     Note:
         The parity of the output depends on the parity of the activation function.
     """
-    input = e3nn.IrrepsArray.as_irreps_array(input)
+    input = e3nn.as_irreps_array(input)
     assert isinstance(input, e3nn.IrrepsArray)
 
     if acts is None:
@@ -180,7 +180,7 @@ def scalar_activation(
             irreps_out, array, zero_flags=[x is None for x in chunks]
         )
 
-    return e3nn.IrrepsArray.from_list(irreps_out, chunks, input.shape[:-1], input.dtype)
+    return e3nn.from_chunks(irreps_out, chunks, input.shape[:-1], input.dtype)
 
 
 def norm_activation(

--- a/e3nn_jax/_src/activation.py
+++ b/e3nn_jax/_src/activation.py
@@ -226,7 +226,7 @@ def norm_activation(
 
         list.append(x)
 
-    return e3nn.IrrepsArray.from_list(input.irreps, list, input.shape[:-1], input.dtype)
+    return e3nn.from_chunks(input.irreps, list, input.shape[:-1], input.dtype)
 
 
 def key_value_activation(phi, key, value):

--- a/e3nn_jax/_src/activation_test.py
+++ b/e3nn_jax/_src/activation_test.py
@@ -4,31 +4,28 @@ import numpy as np
 import pytest
 
 import e3nn_jax as e3nn
-from e3nn_jax import Irreps, IrrepsArray, scalar_activation
 
 
 def test_errors(keys):
     x = e3nn.normal("0e + 1e", keys[0], ())
     with pytest.raises(ValueError):
-        scalar_activation(x, [None, jnp.tanh])
+        e3nn.scalar_activation(x, [None, jnp.tanh])
 
 
 def test_zero_in_zero():
-    x = IrrepsArray.from_list(
-        "0e + 0o + 0o + 0e", [jnp.ones((1, 1)), None, None, None], ()
-    )
-    y = scalar_activation(x, [jnp.tanh, jnp.tanh, lambda x: x**2, jnp.cos])
+    x = e3nn.from_chunks("0e + 0o + 0o + 0e", [jnp.ones((1, 1)), None, None, None], ())
+    y = e3nn.scalar_activation(x, [jnp.tanh, jnp.tanh, lambda x: x**2, jnp.cos])
 
-    assert y.irreps == Irreps("0e + 0o + 0e + 0e")
+    assert y.irreps == e3nn.Irreps("0e + 0o + 0e + 0e")
     assert y.list[1] is None
     assert y.list[2] is None
     assert y.list[3] is not None
 
 
 def test_irreps_argument():
-    assert scalar_activation(
+    assert e3nn.scalar_activation(
         "0e + 0o + 0o + 0e", [jnp.tanh, jnp.tanh, lambda x: x**2, jnp.cos]
-    ) == Irreps("0e + 0o + 0e + 0e")
+    ) == e3nn.Irreps("0e + 0o + 0e + 0e")
 
 
 def test_norm_act():

--- a/e3nn_jax/_src/activation_test.py
+++ b/e3nn_jax/_src/activation_test.py
@@ -17,9 +17,9 @@ def test_zero_in_zero():
     y = e3nn.scalar_activation(x, [jnp.tanh, jnp.tanh, lambda x: x**2, jnp.cos])
 
     assert y.irreps == e3nn.Irreps("0e + 0o + 0e + 0e")
-    assert y.list[1] is None
-    assert y.list[2] is None
-    assert y.list[3] is not None
+    assert y.chunks[1] is None
+    assert y.chunks[2] is None
+    assert y.chunks[3] is not None
 
 
 def test_irreps_argument():

--- a/e3nn_jax/_src/basic.py
+++ b/e3nn_jax/_src/basic.py
@@ -170,13 +170,10 @@ def concatenate(arrays: List[e3nn.IrrepsArray], axis: int = -1) -> e3nn.IrrepsAr
     if {x.irreps for x in arrays} != {arrays[0].irreps}:
         raise ValueError("Irreps must be the same for all arrays")
 
-    arrays = [
-        x.replace_none_with_zeros() for x in arrays
-    ]  # TODO this could be optimized
     return e3nn.IrrepsArray(
         irreps=arrays[0].irreps,
         array=jnp.concatenate([x.array for x in arrays], axis=axis),
-        list=[jnp.concatenate(xs, axis=axis) for xs in zip(*[x.list for x in arrays])],
+        zero_flags=[all(x) for x in zip(*[x.zero_flags for x in arrays])],
     )
 
 
@@ -224,13 +221,10 @@ def stack(arrays: List[e3nn.IrrepsArray], axis=0) -> e3nn.IrrepsArray:
     if {x.irreps for x in arrays} != {arrays[0].irreps}:
         raise ValueError("Irreps must be the same for all arrays")
 
-    arrays = [
-        x.replace_none_with_zeros() for x in arrays
-    ]  # TODO this could be optimized
     return e3nn.IrrepsArray(
         irreps=arrays[0].irreps,
         array=jnp.stack([x.array for x in arrays], axis=axis),
-        list=[jnp.stack(xs, axis=axis) for xs in zip(*[x.list for x in arrays])],
+        zero_flags=[all(x) for x in zip(*[x.zero_flags for x in arrays])],
     )
 
 

--- a/e3nn_jax/_src/basic.py
+++ b/e3nn_jax/_src/basic.py
@@ -55,10 +55,7 @@ def _reduce(
         return e3nn.IrrepsArray(
             array.irreps,
             op(array.array, axis=axis, keepdims=keepdims),
-            [
-                None if x is None else op(x, axis=axis, keepdims=keepdims)
-                for x in array.list
-            ],
+            zero_flags=array.zero_flags,
         )
 
     array = _reduce(op, array, axis=axis[:-1], keepdims=keepdims)
@@ -167,7 +164,7 @@ def concatenate(arrays: List[e3nn.IrrepsArray], axis: int = -1) -> e3nn.IrrepsAr
         return e3nn.IrrepsArray(
             irreps=irreps,
             array=jnp.concatenate([x.array for x in arrays], axis=-1),
-            list=sum([x.list for x in arrays], []),
+            zero_flags=sum([x.zero_flags for x in arrays], ()),
         )
 
     if {x.irreps for x in arrays} != {arrays[0].irreps}:

--- a/e3nn_jax/_src/basic.py
+++ b/e3nn_jax/_src/basic.py
@@ -165,7 +165,7 @@ def _reduce(
     array = _reduce(op, array, axis=axis[:-1], keepdims=keepdims)
     return e3nn.from_chunks(
         e3nn.Irreps([(1, ir) for _, ir in array.irreps]),
-        [None if x is None else op(x, axis=-2, keepdims=True) for x in array.list],
+        [None if x is None else op(x, axis=-2, keepdims=True) for x in array.chunks],
         array.shape[:-1],
         array.dtype,
     )
@@ -372,7 +372,7 @@ def norm(
     if per_irrep:
         return e3nn.from_chunks(
             [(mul, "0e") for mul, _ in array.irreps],
-            [f(x) for x in array.list],
+            [f(x) for x in array.chunks],
             array.shape[:-1],
             array.dtype,
         )
@@ -415,7 +415,7 @@ def dot(
     if per_irrep:
         out = []
         dtype = a.dtype
-        for x, y in zip(a.list, b.list):
+        for x, y in zip(a.chunks, b.chunks):
             if x is None or y is None:
                 out.append(None)
             else:
@@ -429,7 +429,7 @@ def dot(
         )
     else:
         out = 0.0
-        for x, y in zip(a.list, b.list):
+        for x, y in zip(a.chunks, b.chunks):
             if x is None or y is None:
                 continue
             out = out + jnp.sum(jnp.conj(x) * y, axis=(-2, -1))
@@ -474,7 +474,7 @@ def cross(a: e3nn.IrrepsArray, b: e3nn.IrrepsArray) -> e3nn.IrrepsArray:
     dtype = a.dtype
 
     for ((mul, irx), x), ((_, iry), y) in zip(
-        zip(a.irreps, a.list), zip(b.irreps, b.list)
+        zip(a.irreps, a.chunks), zip(b.irreps, b.chunks)
     ):
         irreps_out.append((mul, (1, irx.p * iry.p)))
         if x is None or y is None:

--- a/e3nn_jax/_src/basic.py
+++ b/e3nn_jax/_src/basic.py
@@ -9,6 +9,43 @@ from e3nn_jax._src.irreps import IntoIrreps
 from e3nn_jax._src.irreps_array import _infer_backend, _standardize_axis
 
 
+def as_irreps_array(array: Union[jnp.ndarray, e3nn.IrrepsArray], *, backend=None):
+    """Convert an array to an IrrepsArray.
+
+    Args:
+        array (jax.numpy.ndarray or IrrepsArray): array to convert
+
+    Returns:
+        IrrepsArray
+    """
+    if isinstance(array, e3nn.IrrepsArray):
+        return array
+
+    jnp = _infer_backend(array) if backend is None else backend
+    array = jnp.asarray(array)
+
+    if array.ndim == 0:
+        raise ValueError(
+            "IrrepsArray.as_irreps_array: Cannot convert an array of rank 0 to an IrrepsArray."
+        )
+
+    return e3nn.IrrepsArray(f"{array.shape[-1]}x0e", array)
+
+
+def zeros(irreps: IntoIrreps, leading_shape, dtype=None) -> e3nn.IrrepsArray:
+    r"""Create an IrrepsArray of zeros."""
+    irreps = e3nn.Irreps(irreps)
+    array = jnp.zeros(leading_shape + (irreps.dim,), dtype=dtype)
+    return e3nn.IrrepsArray(irreps, array, zero_flags=(True,) * len(irreps))
+
+
+def zeros_like(irreps_array: e3nn.IrrepsArray) -> e3nn.IrrepsArray:
+    r"""Create an IrrepsArray of zeros with the same shape as another IrrepsArray."""
+    return e3nn.IrrepsArray.zeros(
+        irreps_array.irreps, irreps_array.shape[:-1], irreps_array.dtype
+    )
+
+
 def _align_two_irreps_arrays(
     input1: e3nn.IrrepsArray, input2: e3nn.IrrepsArray
 ) -> Tuple[e3nn.IrrepsArray, e3nn.IrrepsArray]:

--- a/e3nn_jax/_src/basic.py
+++ b/e3nn_jax/_src/basic.py
@@ -136,8 +136,8 @@ def _align_two_irreps_arrays(
 
         i += 1
 
-    input1 = input1._convert(irreps_in1)
-    input2 = input2._convert(irreps_in2)
+    input1 = input1.rechunk(irreps_in1)
+    input2 = input2.rechunk(irreps_in2)
 
     assert [mul for mul, _ in input1.irreps] == [mul for mul, _ in input2.irreps]
     return input1, input2

--- a/e3nn_jax/_src/batchnorm_haiku.py
+++ b/e3nn_jax/_src/batchnorm_haiku.py
@@ -193,7 +193,7 @@ class BatchNorm(hk.Module):
             output: normalized tensor of shape ``(batch, [spatial], irreps.dim)``
         """
         if self.irreps is not None:
-            input = input._convert(self.irreps)
+            input = input.rechunk(self.irreps)
 
         num_scalar = sum(mul for mul, ir in input.irreps if ir.is_scalar())
         num_features = input.irreps.num_irreps

--- a/e3nn_jax/_src/batchnorm_haiku.py
+++ b/e3nn_jax/_src/batchnorm_haiku.py
@@ -40,7 +40,7 @@ def _batch_norm(
     i_rmu = 0  # index for running_mean
     i_bia = 0  # index for bias
 
-    for (mul, ir), field in zip(input.irreps, input.list):
+    for (mul, ir), field in zip(input.irreps, input.chunks):
         if field is None:
             # [batch, sample, mul, repr]
             if ir.is_scalar():  # scalars
@@ -120,7 +120,7 @@ def _batch_norm(
             fields.append(field)  # [batch, sample, mul, repr]
         i_wei += mul
 
-    output = e3nn.from_list(input.irreps, fields, (batch, prod(size)), input.dtype)
+    output = e3nn.from_chunks(input.irreps, fields, (batch, prod(size)), input.dtype)
     output = output.reshape((batch,) + tuple(size) + (-1,))
     return output, new_means, new_vars
 

--- a/e3nn_jax/_src/batchnorm_haiku.py
+++ b/e3nn_jax/_src/batchnorm_haiku.py
@@ -5,7 +5,7 @@ import haiku as hk
 import jax
 import jax.numpy as jnp
 
-from e3nn_jax import Irreps, IrrepsArray, config
+import e3nn_jax as e3nn
 
 
 @partial(jax.jit, static_argnums=(5, 6, 7, 8, 9, 10, 11))
@@ -120,9 +120,7 @@ def _batch_norm(
             fields.append(field)  # [batch, sample, mul, repr]
         i_wei += mul
 
-    output = IrrepsArray.from_list(
-        input.irreps, fields, (batch, prod(size)), input.dtype
-    )
+    output = e3nn.from_list(input.irreps, fields, (batch, prod(size)), input.dtype)
     output = output.reshape((batch,) + tuple(size) + (-1,))
     return output, new_means, new_vars
 
@@ -149,7 +147,7 @@ class BatchNorm(hk.Module):
     def __init__(
         self,
         *,
-        irreps: Irreps = None,
+        irreps: e3nn.Irreps = None,
         eps: float = 1e-4,
         momentum: float = 0.1,
         affine: bool = True,
@@ -161,7 +159,7 @@ class BatchNorm(hk.Module):
 
         # TODO test with and without irreps argument given
 
-        self.irreps = Irreps(irreps) if irreps is not None else irreps
+        self.irreps = e3nn.Irreps(irreps) if irreps is not None else irreps
         self.eps = eps
         self.momentum = momentum
         self.affine = affine
@@ -172,7 +170,7 @@ class BatchNorm(hk.Module):
         self.reduce = reduce
 
         if normalization is None:
-            normalization = config("irrep_normalization")
+            normalization = e3nn.config("irrep_normalization")
         assert normalization in [
             "norm",
             "component",
@@ -182,7 +180,9 @@ class BatchNorm(hk.Module):
     def __repr__(self):
         return f"{self.__class__.__name__} ({self.irreps}, eps={self.eps}, momentum={self.momentum})"
 
-    def __call__(self, input: IrrepsArray, is_training: bool = True) -> IrrepsArray:
+    def __call__(
+        self, input: e3nn.IrrepsArray, is_training: bool = True
+    ) -> e3nn.IrrepsArray:
         r"""Evaluate the batch normalization.
 
         Args:

--- a/e3nn_jax/_src/batchnorm_haiku_test.py
+++ b/e3nn_jax/_src/batchnorm_haiku_test.py
@@ -74,11 +74,11 @@ def test_normalization(keys, instance):
     x = e3nn.normal(irreps, next(keys), (batch, n)) * 5
     x, state = b.apply(params, state, x)
 
-    a = x.list[0]  # [batch, space, mul, 1]
+    a = x.chunks[0]  # [batch, space, mul, 1]
     assert jnp.max(jnp.abs(a.mean([0, 1]))) < float_tolerance
     assert jnp.max(jnp.abs(jnp.square(a).mean([0, 1]) - 1)) < sqrt_float_tolerance
 
-    a = x.list[1]  # [batch, space, mul, repr]
+    a = x.chunks[1]  # [batch, space, mul, repr]
     assert (
         jnp.max(jnp.abs(jnp.square(a).sum(3).mean([0, 1]) - 1)) < sqrt_float_tolerance
     )
@@ -96,11 +96,11 @@ def test_normalization(keys, instance):
     x = e3nn.normal(irreps, next(keys), (batch, n)) * 5
     x, state = b.apply(params, state, x)
 
-    a = x.list[0]  # [batch, space, mul, 1]
+    a = x.chunks[0]  # [batch, space, mul, 1]
     assert jnp.max(jnp.abs(a.mean([0, 1]))) < float_tolerance
     assert jnp.max(jnp.abs(jnp.square(a).mean([0, 1]) - 1)) < sqrt_float_tolerance
 
-    a = x.list[1]  # [batch, space, mul, repr]
+    a = x.chunks[1]  # [batch, space, mul, repr]
     assert (
         jnp.max(jnp.abs(jnp.square(a).mean(3).mean([0, 1]) - 1)) < sqrt_float_tolerance
     )

--- a/e3nn_jax/_src/config_test.py
+++ b/e3nn_jax/_src/config_test.py
@@ -8,7 +8,7 @@ def test_config(keys):
     assert e3nn.config("irrep_normalization") == "component"
 
     inputs = e3nn.normal("10x1e", keys[0], (2,))
-    s, p, d = e3nn.elementwise_tensor_product(inputs[0], inputs[1]).list
+    s, p, d = e3nn.elementwise_tensor_product(inputs[0], inputs[1]).chunks
 
     assert jnp.exp(jnp.abs(jnp.log(jnp.mean(p**2)))) < 2.0
     assert jnp.exp(jnp.abs(jnp.log(jnp.mean(d**2)))) < 2.0
@@ -17,7 +17,7 @@ def test_config(keys):
     assert e3nn.config("irrep_normalization") == "norm"
 
     inputs = e3nn.normal("10x1e", keys[0], (2,))
-    s, p, d = e3nn.elementwise_tensor_product(inputs[0], inputs[1]).list
+    s, p, d = e3nn.elementwise_tensor_product(inputs[0], inputs[1]).chunks
 
     assert jnp.exp(jnp.abs(jnp.log(jnp.mean(jnp.sum(p**2, axis=1))))) < 2.0
     assert jnp.exp(jnp.abs(jnp.log(jnp.mean(jnp.sum(d**2, axis=1))))) < 2.0

--- a/e3nn_jax/_src/core_tensor_product.py
+++ b/e3nn_jax/_src/core_tensor_product.py
@@ -170,8 +170,8 @@ class FunctionalTensorProduct:
         return _left_right(
             self,
             weights,
-            input1._convert(self.irreps_in1),
-            input2._convert(self.irreps_in2),
+            input1.rechunk(self.irreps_in1),
+            input2.rechunk(self.irreps_in2),
             custom_einsum_jvp=custom_einsum_jvp,
             fused=fused,
             sparse=sparse,
@@ -203,7 +203,7 @@ class FunctionalTensorProduct:
         return _right(
             self,
             weights,
-            input2._convert(self.irreps_in2),
+            input2.rechunk(self.irreps_in2),
             custom_einsum_jvp=custom_einsum_jvp,
         )
 

--- a/e3nn_jax/_src/core_tensor_product.py
+++ b/e3nn_jax/_src/core_tensor_product.py
@@ -13,6 +13,7 @@ from jax.experimental.sparse import BCOO, sparsify
 from e3nn_jax import Instruction, Irreps, IrrepsArray, clebsch_gordan, config
 from e3nn_jax._src.einsum import einsum as opt_einsum
 from e3nn_jax._src.utils.dtype import get_pytree_dtype
+import e3nn_jax as e3nn
 
 
 class FunctionalTensorProduct:
@@ -333,7 +334,7 @@ def _left_right(
         dtype = jnp.float32
 
     if self.irreps_in1.dim == 0 or self.irreps_in2.dim == 0 or self.irreps_out.dim == 0:
-        return IrrepsArray.zeros(self.irreps_out, (), dtype)
+        return e3nn.zeros(self.irreps_out, (), dtype)
 
     if sparse:
         assert (

--- a/e3nn_jax/_src/core_tensor_product.py
+++ b/e3nn_jax/_src/core_tensor_product.py
@@ -511,7 +511,7 @@ def _block_left_right(
         )
         for i_out, mul_ir_out in enumerate(self.irreps_out)
     ]
-    return IrrepsArray.from_list(self.irreps_out, out, (), dtype)
+    return e3nn.from_chunks(self.irreps_out, out, (), dtype)
 
 
 def _fused_left_right(

--- a/e3nn_jax/_src/core_tensor_product.py
+++ b/e3nn_jax/_src/core_tensor_product.py
@@ -403,9 +403,9 @@ def _block_left_right(
     @lru_cache(maxsize=None)
     def multiply(in1, in2, mode):
         if mode == "uv":
-            return einsum("ui,vj->uvij", input1.list[in1], input2.list[in2])
+            return einsum("ui,vj->uvij", input1.chunks[in1], input2.chunks[in2])
         if mode == "uu":
-            return einsum("ui,uj->uij", input1.list[in1], input2.list[in2])
+            return einsum("ui,uj->uij", input1.chunks[in1], input2.chunks[in2])
 
     weight_index = 0
 
@@ -426,8 +426,8 @@ def _block_left_right(
             # out_list += [None]
             continue
 
-        x1 = input1.list[ins.i_in1]
-        x2 = input2.list[ins.i_in2]
+        x1 = input1.chunks[ins.i_in1]
+        x2 = input2.chunks[ins.i_in2]
 
         if x1 is None or x2 is None:
             out_list += [None]
@@ -655,7 +655,7 @@ def _right(
         mul_ir_in2 = self.irreps_in2[ins.i_in2]
         mul_ir_out = self.irreps_out[ins.i_out]
 
-        x2 = input2.list[ins.i_in2]
+        x2 = input2.chunks[ins.i_in2]
 
         if ins.has_weight:
             w = weights[weight_index]

--- a/e3nn_jax/_src/core_tensor_product_test.py
+++ b/e3nn_jax/_src/core_tensor_product_test.py
@@ -179,7 +179,7 @@ def test_normalization(
     x1 = e3nn.normal(tp.irreps_in1, next(keys), (), normalization=irrep_normalization)
     x2 = e3nn.normal(tp.irreps_in2, next(keys), (), normalization=irrep_normalization)
 
-    v, s = tp.left_right(ws, x1, x2).list
+    v, s = tp.left_right(ws, x1, x2).chunks
 
     assert jnp.exp(jnp.abs(jnp.log(jnp.mean(s**2)))) < 2.0
     if irrep_normalization == "component":

--- a/e3nn_jax/_src/dropout_haiku.py
+++ b/e3nn_jax/_src/dropout_haiku.py
@@ -57,7 +57,7 @@ class Dropout(hk.Module):
 
         noises = []
         zero_flags = []
-        for (mul, ir), a in zip(x.irreps, x.list):
+        for (mul, ir), a in zip(x.irreps, x.chunks):
             if self.p >= 1:
                 zero_flags.append(True)
                 noises.append(jnp.zeros((mul * ir.dim,), x.dtype))

--- a/e3nn_jax/_src/dropout_haiku.py
+++ b/e3nn_jax/_src/dropout_haiku.py
@@ -56,20 +56,23 @@ class Dropout(hk.Module):
             raise TypeError(f"{self.__class__.__name__} only supports IrrepsArray")
 
         noises = []
-        out_list = []
+        zero_flags = []
         for (mul, ir), a in zip(x.irreps, x.list):
             if self.p >= 1:
-                out_list.append(None)
+                zero_flags.append(True)
                 noises.append(jnp.zeros((mul * ir.dim,), x.dtype))
             elif self.p <= 0:
-                out_list.append(a)
+                zero_flags.append(False)
                 noises.append(jnp.ones((mul * ir.dim,), x.dtype))
+            elif a is None:
+                zero_flags.append(True)
+                noises.append(jnp.zeros((mul * ir.dim,), x.dtype))
             else:
                 noise = jax.random.bernoulli(rng, p=1 - self.p, shape=(mul, 1)) / (
                     1 - self.p
                 )
-                out_list.append(noise * a)
+                zero_flags.append(False)
                 noises.append(jnp.repeat(noise, ir.dim, axis=1).flatten())
 
         noises = jnp.concatenate(noises)
-        return IrrepsArray(irreps=x.irreps, array=x.array * noises, list=out_list)
+        return IrrepsArray(x.irreps, x.array * noises, zero_flags=zero_flags)

--- a/e3nn_jax/_src/dropout_haiku.py
+++ b/e3nn_jax/_src/dropout_haiku.py
@@ -51,7 +51,7 @@ class Dropout(hk.Module):
             return x
 
         if self.irreps is not None:
-            x = x._convert(self.irreps)
+            x = x.rechunk(self.irreps)
         if not isinstance(x, IrrepsArray):
             raise TypeError(f"{self.__class__.__name__} only supports IrrepsArray")
 

--- a/e3nn_jax/_src/fc_tp_haiku.py
+++ b/e3nn_jax/_src/fc_tp_haiku.py
@@ -20,8 +20,8 @@ class FullyConnectedTensorProduct(hk.Module):
         if self.irreps_in2 is not None:
             x2 = x2._convert(self.irreps_in2)
 
-        x1 = x1.remove_nones().simplify()
-        x2 = x2.remove_nones().simplify()
+        x1 = x1.remove_zero_chunks().simplify()
+        x2 = x2.remove_zero_chunks().simplify()
 
         tp = e3nn.FunctionalFullyConnectedTensorProduct(
             x1.irreps, x2.irreps, self.irreps_out.simplify()

--- a/e3nn_jax/_src/fc_tp_haiku.py
+++ b/e3nn_jax/_src/fc_tp_haiku.py
@@ -16,9 +16,9 @@ class FullyConnectedTensorProduct(hk.Module):
         self, x1: e3nn.IrrepsArray, x2: e3nn.IrrepsArray, **kwargs
     ) -> e3nn.IrrepsArray:
         if self.irreps_in1 is not None:
-            x1 = x1._convert(self.irreps_in1)
+            x1 = x1.rechunk(self.irreps_in1)
         if self.irreps_in2 is not None:
-            x2 = x2._convert(self.irreps_in2)
+            x2 = x2.rechunk(self.irreps_in2)
 
         x1 = x1.remove_zero_chunks().simplify()
         x2 = x2.remove_zero_chunks().simplify()

--- a/e3nn_jax/_src/fc_tp_haiku.py
+++ b/e3nn_jax/_src/fc_tp_haiku.py
@@ -41,4 +41,4 @@ class FullyConnectedTensorProduct(hk.Module):
             lambda x1, x2: tp.left_right(ws, x1, x2, **kwargs)
         )
         output = f(x1, x2)
-        return output._convert(self.irreps_out)
+        return output.rechunk(self.irreps_out)

--- a/e3nn_jax/_src/grad.py
+++ b/e3nn_jax/_src/grad.py
@@ -46,7 +46,7 @@ def grad(
 
         def naked_fun(*args, **kwargs) -> List[jnp.ndarray]:
             args = list(args)
-            args[argnums] = e3nn.IrrepsArray.from_list(
+            args[argnums] = e3nn.from_chunks(
                 irreps_in, args[argnums], leading_shape_in, x.dtype
             )
             if has_aux:
@@ -110,7 +110,7 @@ def grad(
                             + (mir_out.mul * mir_in.mul, ir.dim)
                         )
                     )
-        output = e3nn.IrrepsArray.from_list(
+        output = e3nn.from_chunks(
             irreps, lst, leading_shape_out + leading_shape_in, x.dtype
         )
         if regroup_output:

--- a/e3nn_jax/_src/grad.py
+++ b/e3nn_jax/_src/grad.py
@@ -41,7 +41,8 @@ def grad(
             raise TypeError(f"arg{argnums} must be an e3nn.IrrepsArray.")
         irreps_in = x.irreps
         leading_shape_in = x.shape[:-1]
-        args[argnums] = x.list
+        x = e3nn.IrrepsArray(x.irreps, x.array)  # drop zero_flags
+        args[argnums] = x.chunks
 
         def naked_fun(*args, **kwargs) -> List[jnp.ndarray]:
             args = list(args)
@@ -54,14 +55,14 @@ def grad(
                     raise TypeError(
                         f"Expected equivariant function to return an e3nn.IrrepsArray, got {type(y)}."
                     )
-                return y.list, (y.irreps, y.shape[:-1], aux)
+                return y.chunks, (y.irreps, y.shape[:-1], aux)
             else:
                 y = fun(*args, **kwargs)
                 if not isinstance(y, e3nn.IrrepsArray):
                     raise TypeError(
                         f"Expected equivariant function to return an e3nn.IrrepsArray, got {type(y)}."
                     )
-                return y.list, (y.irreps, y.shape[:-1])
+                return y.chunks, (y.irreps, y.shape[:-1])
 
         output = jax.jacobian(
             naked_fun,

--- a/e3nn_jax/_src/grad.py
+++ b/e3nn_jax/_src/grad.py
@@ -41,7 +41,6 @@ def grad(
             raise TypeError(f"arg{argnums} must be an e3nn.IrrepsArray.")
         irreps_in = x.irreps
         leading_shape_in = x.shape[:-1]
-        x = x.replace_none_with_zeros()
         args[argnums] = x.list
 
         def naked_fun(*args, **kwargs) -> List[jnp.ndarray]:

--- a/e3nn_jax/_src/grad_test.py
+++ b/e3nn_jax/_src/grad_test.py
@@ -26,6 +26,14 @@ def test_simple_grad():
     )
 
 
+def test_grad_in_zero():
+    def fn(x):
+        return e3nn.sum(x)
+
+    x = e3nn.IrrepsArray.zeros("0e", ())
+    np.testing.assert_allclose(e3nn.grad(fn)(x).array, 1.0, atol=1e-6, rtol=1e-6)
+
+
 def test_aux():
     def fn(x):
         return e3nn.sum(0.5 * e3nn.norm(x, squared=True).simplify()), x.irreps

--- a/e3nn_jax/_src/grad_test.py
+++ b/e3nn_jax/_src/grad_test.py
@@ -30,7 +30,7 @@ def test_grad_in_zero():
     def fn(x):
         return e3nn.sum(x)
 
-    x = e3nn.IrrepsArray.zeros("0e", ())
+    x = e3nn.zeros("0e", ())
     np.testing.assert_allclose(e3nn.grad(fn)(x).array, 1.0, atol=1e-6, rtol=1e-6)
 
 

--- a/e3nn_jax/_src/irreps_array.py
+++ b/e3nn_jax/_src/irreps_array.py
@@ -625,7 +625,12 @@ class IrrepsArray:
             backend=_infer_backend(self.array),
         )
 
-    sorted = sort
+    def sorted(self) -> "IrrepsArray":
+        warnings.warn(
+            "IrrepsArray.sorted is deprecated, use IrrepsArray.sort instead.",
+            DeprecationWarning,
+        )
+        return self.sort()
 
     def regroup(self) -> "IrrepsArray":
         r"""Regroup the same irreps together.
@@ -673,7 +678,12 @@ class IrrepsArray:
             backend=backend,
         )
 
-    filtered = filter
+    def filtered(self, *args, **kwargs) -> "IrrepsArray":
+        warnings.warn(
+            "IrrepsArray.filtered is deprecated, use IrrepsArray.filter instead.",
+            DeprecationWarning,
+        )
+        return self.filter(*args, **kwargs)
 
     @property
     def slice_by_mul(self):
@@ -769,6 +779,13 @@ class IrrepsArray:
             irreps, new_list, self.shape[:-1] + (factor,), self.dtype
         )
 
+    def factor_mul_to_last_axis(self, axis: int = -2) -> "IrrepsArray":
+        warnings.warn(
+            "IrrepsArray.factor_mul_to_last_axis is deprecated. Use IrrepsArray.mul_to_axis instead.",
+            DeprecationWarning,
+        )
+        return self.mul_to_axis(axis=axis)
+
     def axis_to_mul(self, axis: int = -2) -> "IrrepsArray":
         r"""Repeat the multiplicity by the previous last axis of the array.
 
@@ -800,8 +817,12 @@ class IrrepsArray:
         ]
         return e3nn.from_chunks(new_irreps, new_list, self.shape[:-2], self.dtype)
 
-    repeat_mul_by_last_axis = axis_to_mul
-    factor_mul_to_last_axis = mul_to_axis
+    def repeat_mul_by_last_axis(self, axis: int = -2) -> "IrrepsArray":
+        warnings.warn(
+            "IrrepsArray.repeat_mul_by_last_axis is deprecated. Use IrrepsArray.axis_to_mul instead.",
+            DeprecationWarning,
+        )
+        return self.axis_to_mul(axis=axis)
 
     def transform_by_log_coordinates(
         self, log_coordinates: jnp.ndarray, k: int = 0

--- a/e3nn_jax/_src/irreps_array.py
+++ b/e3nn_jax/_src/irreps_array.py
@@ -111,14 +111,6 @@ class IrrepsArray:
 
     @staticmethod
     def as_irreps_array(array: Union[jnp.ndarray, "IrrepsArray"], *, backend=None):
-        """Convert an array to an IrrepsArray.
-
-        Args:
-            array (jax.numpy.ndarray or IrrepsArray): array to convert
-
-        Returns:
-            IrrepsArray
-        """
         warnings.warn(
             "IrrepsArray.as_irreps_array is deprecated, use e3nn.as_irreps_array instead.",
             DeprecationWarning,
@@ -127,7 +119,6 @@ class IrrepsArray:
 
     @staticmethod
     def zeros(irreps: IntoIrreps, leading_shape, dtype=None) -> "IrrepsArray":
-        r"""Create an IrrepsArray of zeros."""
         warnings.warn(
             "IrrepsArray.zeros is deprecated, use e3nn.zeros instead.",
             DeprecationWarning,
@@ -136,7 +127,6 @@ class IrrepsArray:
 
     @staticmethod
     def zeros_like(irreps_array: "IrrepsArray") -> "IrrepsArray":
-        r"""Create an IrrepsArray of zeros with the same shape as another IrrepsArray."""
         warnings.warn(
             "IrrepsArray.zeros_like is deprecated, use e3nn.zeros_like instead.",
             DeprecationWarning,
@@ -578,7 +568,6 @@ class IrrepsArray:
         )
 
     def remove_nones(self) -> "IrrepsArray":
-        r"""Remove all None in ``.chunks`` and ``.irreps``."""
         warnings.warn(
             "IrrepsArray.remove_nones is deprecated. Use IrrepsArray.remove_zero_chunks instead.",
             DeprecationWarning,

--- a/e3nn_jax/_src/irreps_array.py
+++ b/e3nn_jax/_src/irreps_array.py
@@ -628,7 +628,7 @@ class IrrepsArray:
             1x0e+2x0e+1x1o [0 4 5 1 2 3]
         """
         irreps, p, inv = self.irreps.sort()
-        return IrrepsArray.from_list(
+        return e3nn.from_chunks(
             irreps,
             [self.list[i] for i in inv],
             self.shape[:-1],
@@ -776,7 +776,7 @@ class IrrepsArray:
             for (mul, ir), x in zip(irreps, self.list)
         ]
         new_list = [None if x is None else jnp.moveaxis(x, -3, axis) for x in new_list]
-        return IrrepsArray.from_list(
+        return e3nn.from_chunks(
             irreps, new_list, self.shape[:-1] + (factor,), self.dtype
         )
 
@@ -807,7 +807,7 @@ class IrrepsArray:
             None if x is None else x.reshape(self.shape[:-2] + (new_mul, ir.dim))
             for (new_mul, ir), x in zip(new_irreps, new_list)
         ]
-        return IrrepsArray.from_list(new_irreps, new_list, self.shape[:-2], self.dtype)
+        return e3nn.from_chunks(new_irreps, new_list, self.shape[:-2], self.dtype)
 
     repeat_mul_by_last_axis = axis_to_mul
     factor_mul_to_last_axis = mul_to_axis
@@ -837,7 +837,7 @@ class IrrepsArray:
             else None
             for (mul, ir), x in zip(self.irreps, self.list)
         ]
-        return IrrepsArray.from_list(self.irreps, new_list, self.shape[:-1], self.dtype)
+        return e3nn.from_chunks(self.irreps, new_list, self.shape[:-1], self.dtype)
 
     def transform_by_angles(
         self, alpha: float, beta: float, gamma: float, k: int = 0, inverse: bool = False
@@ -889,7 +889,7 @@ class IrrepsArray:
             else None
             for (mul, ir), x in zip(self.irreps, self.list)
         ]
-        return IrrepsArray.from_list(self.irreps, new_list, self.shape[:-1], self.dtype)
+        return e3nn.from_chunks(self.irreps, new_list, self.shape[:-1], self.dtype)
 
     def transform_by_quaternion(self, q: jnp.ndarray, k: int = 0) -> "IrrepsArray":
         r"""Rotate data by a rotation given by a quaternion.
@@ -949,7 +949,7 @@ class IrrepsArray:
             ValueError: if the irreps are not compatible
 
         Examples:
-            >>> x = IrrepsArray.from_list("6x0e + 4x0e", [None, jnp.ones((4, 1))], ())
+            >>> x = e3nn.from_chunks("6x0e + 4x0e", [None, jnp.ones((4, 1))], ())
             >>> x._convert("5x0e + 5x0e").list
             [None, Array([[0.],
                    [1.],
@@ -1196,7 +1196,7 @@ class _ChunkIndexSliceHelper:
             )
         start, stop, stride = index.indices(len(self.irreps_array.irreps))
 
-        return IrrepsArray.from_list(
+        return e3nn.from_chunks(
             self.irreps_array.irreps[start:stop:stride],
             self.irreps_array.list[start:stop:stride],
             self.irreps_array.shape[:-1],

--- a/e3nn_jax/_src/irreps_array.py
+++ b/e3nn_jax/_src/irreps_array.py
@@ -56,7 +56,7 @@ class IrrepsArray:
     Examples:
         >>> import e3nn_jax as e3nn
         >>> x = e3nn.IrrepsArray("1o + 2x0e", jnp.ones(5))
-        >>> y = e3nn.IrrepsArray.from_list("1o + 2x0e", [None, jnp.ones((2, 1))], ())
+        >>> y = e3nn.from_chunks("1o + 2x0e", [None, jnp.ones((2, 1))], ())
         >>> x + y
         1x1o+2x0e [1. 1. 1. 2. 2.]
 

--- a/e3nn_jax/_src/irreps_array.py
+++ b/e3nn_jax/_src/irreps_array.py
@@ -180,7 +180,6 @@ class IrrepsArray:
 
         return IrrepsArray(irreps, array, zero_flags=zero_flags)
 
-    # TODO move to e3nn.as_irreps_array?
     @staticmethod
     def as_irreps_array(array: Union[jnp.ndarray, "IrrepsArray"], *, backend=None):
         """Convert an array to an IrrepsArray.
@@ -191,32 +190,29 @@ class IrrepsArray:
         Returns:
             IrrepsArray
         """
-        if isinstance(array, IrrepsArray):
-            return array
-
-        jnp = _infer_backend(array) if backend is None else backend
-        array = jnp.asarray(array)
-
-        if array.ndim == 0:
-            raise ValueError(
-                "IrrepsArray.as_irreps_array: Cannot convert an array of rank 0 to an IrrepsArray."
-            )
-
-        return IrrepsArray(f"{array.shape[-1]}x0e", array)
+        warnings.warn(
+            "IrrepsArray.as_irreps_array is deprecated, use e3nn.as_irreps_array instead.",
+            DeprecationWarning,
+        )
+        return e3nn.as_irreps_array(array)
 
     @staticmethod
     def zeros(irreps: IntoIrreps, leading_shape, dtype=None) -> "IrrepsArray":
         r"""Create an IrrepsArray of zeros."""
-        irreps = Irreps(irreps)
-        array = jnp.zeros(leading_shape + (irreps.dim,), dtype=dtype)
-        return IrrepsArray(irreps, array, zero_flags=(True,) * len(irreps))
+        warnings.warn(
+            "IrrepsArray.zeros is deprecated, use e3nn.zeros instead.",
+            DeprecationWarning,
+        )
+        return e3nn.zeros(irreps, leading_shape, dtype)
 
     @staticmethod
     def zeros_like(irreps_array: "IrrepsArray") -> "IrrepsArray":
         r"""Create an IrrepsArray of zeros with the same shape as another IrrepsArray."""
-        return IrrepsArray.zeros(
-            irreps_array.irreps, irreps_array.shape[:-1], irreps_array.dtype
+        warnings.warn(
+            "IrrepsArray.zeros_like is deprecated, use e3nn.zeros_like instead.",
+            DeprecationWarning,
         )
+        return e3nn.zeros_like(irreps_array)
 
     @property
     def list(self) -> List[Optional[jnp.ndarray]]:

--- a/e3nn_jax/_src/irreps_array.py
+++ b/e3nn_jax/_src/irreps_array.py
@@ -648,17 +648,10 @@ class IrrepsArray:
             zero_flags=self.zero_flags,
         )
 
-    def replace_none_with_zeros(self) -> "IrrepsArray":
-        r"""Replace all None in ``.list`` with zeros."""
-        warnings.warn(
-            "IrrepsArray.replace_none_with_zeros is deprecated.", DeprecationWarning
-        )
-        return IrrepsArray(self.irreps, self.array)
-
     def remove_nones(self) -> "IrrepsArray":
         r"""Remove all None in ``.list`` and ``.irreps``."""
         warnings.warn(
-            "IrrepsArray.remove_nones is deprecated. Use .remove_zeros instead.",
+            "IrrepsArray.remove_nones is deprecated. Use IrrepsArray.remove_zero_chunks instead.",
             DeprecationWarning,
         )
         return self.remove_zero_chunks()

--- a/e3nn_jax/_src/irreps_array_test.py
+++ b/e3nn_jax/_src/irreps_array_test.py
@@ -17,15 +17,15 @@ def test_empty():
 def test_convert():
     id = e3nn.from_chunks("10x0e + 10x0e", [None, jnp.ones((1, 10, 1))], (1,))
     assert jax.tree_util.tree_map(
-        jnp.shape, id._convert("0x0e + 20x0e + 0x0e").chunks
+        jnp.shape, id.rechunk("0x0e + 20x0e + 0x0e").chunks
     ) == [None, (1, 20, 1), None]
     assert jax.tree_util.tree_map(
-        jnp.shape, id._convert("7x0e + 4x0e + 9x0e").chunks
+        jnp.shape, id.rechunk("7x0e + 4x0e + 9x0e").chunks
     ) == [None, (1, 4, 1), (1, 9, 1)]
 
     id = e3nn.from_chunks("10x0e + 10x1e", [None, jnp.ones((1, 10, 3))], (1,))
     assert jax.tree_util.tree_map(
-        jnp.shape, id._convert("5x0e + 5x0e + 5x1e + 5x1e").chunks
+        jnp.shape, id.rechunk("5x0e + 5x0e + 5x1e + 5x1e").chunks
     ) == [
         None,
         None,
@@ -34,7 +34,7 @@ def test_convert():
     ]
 
     id = e3nn.zeros("10x0e + 10x1e", ())
-    id = id._convert("5x0e + 0x2e + 5x0e + 0x2e + 5x1e + 5x1e")
+    id = id.rechunk("5x0e + 0x2e + 5x0e + 0x2e + 5x1e + 5x1e")
 
     a = e3nn.from_chunks(
         "            10x0e  +  0x0e +1x1e  +     0x0e    +          9x1e           + 0x0e",
@@ -48,7 +48,7 @@ def test_convert():
         ],
         (2,),
     )
-    b = a._convert("5x0e + 0x2e + 5x0e + 0x2e + 5x1e + 5x1e")
+    b = a.rechunk("5x0e + 0x2e + 5x0e + 0x2e + 5x1e + 5x1e")
     b = e3nn.from_chunks(b.irreps, b.chunks, b.shape[:-1])
 
     np.testing.assert_allclose(a.array, b.array)

--- a/e3nn_jax/_src/irreps_array_test.py
+++ b/e3nn_jax/_src/irreps_array_test.py
@@ -49,7 +49,7 @@ def test_convert():
         (2,),
     )
     b = a._convert("5x0e + 0x2e + 5x0e + 0x2e + 5x1e + 5x1e")
-    b = e3nn.from_chunks(b.irreps, b.list, b.shape[:-1])
+    b = e3nn.from_chunks(b.irreps, b.chunks, b.shape[:-1])
 
     np.testing.assert_allclose(a.array, b.array)
 
@@ -153,21 +153,21 @@ def test_at_set():
     y = x.at[0, 1].set(0)
     assert y.shape == x.shape
     np.testing.assert_allclose(y[0, 1].array, 0)
-    np.testing.assert_allclose(y[0, 1].list[0], 0)
-    np.testing.assert_allclose(y[0, 1].list[1], 0)
+    np.testing.assert_allclose(y[0, 1].chunks[0], 0)
+    np.testing.assert_allclose(y[0, 1].chunks[1], 0)
     np.testing.assert_allclose(y[0, 2].array, x[0, 2].array)
-    np.testing.assert_allclose(y[0, 2].list[0], x[0, 2].list[0])
-    np.testing.assert_allclose(y[0, 2].list[1], x[0, 2].list[1])
+    np.testing.assert_allclose(y[0, 2].chunks[0], x[0, 2].chunks[0])
+    np.testing.assert_allclose(y[0, 2].chunks[1], x[0, 2].chunks[1])
 
     v = e3nn.IrrepsArray("0e + 1e", jnp.arange(4 * 4).reshape((4, 4)))
     y = x.at[1].set(v)
     assert y.shape == x.shape
     np.testing.assert_allclose(y[1].array, v.array)
-    np.testing.assert_allclose(y[1].list[0], v.list[0])
-    np.testing.assert_allclose(y[1].list[1], v.list[1])
+    np.testing.assert_allclose(y[1].chunks[0], v.chunks[0])
+    np.testing.assert_allclose(y[1].chunks[1], v.chunks[1])
     np.testing.assert_allclose(y[0].array, x[0].array)
-    np.testing.assert_allclose(y[0].list[0], x[0].list[0])
-    np.testing.assert_allclose(y[0].list[1], x[0].list[1])
+    np.testing.assert_allclose(y[0].chunks[0], x[0].chunks[0])
+    np.testing.assert_allclose(y[0].chunks[1], x[0].chunks[1])
 
 
 def test_at_add():
@@ -183,14 +183,14 @@ def test_at_add():
     y1 = x.at[0].add(v)
     y2 = e3nn.IrrepsArray(x.irreps, x.array.at[0].add(v.array))
     np.testing.assert_array_equal(y1.array, y2.array)
-    assert y1.list[0] is None
-    assert y1.list[1] is not None
-    assert y1.list[2] is not None
-    assert y1.list[3] is not None
-    np.testing.assert_allclose(0, y2.list[0])
-    np.testing.assert_array_equal(y1.list[1], y2.list[1])
-    np.testing.assert_array_equal(y1.list[2], y2.list[2])
-    np.testing.assert_array_equal(y1.list[3], y2.list[3])
+    assert y1.chunks[0] is None
+    assert y1.chunks[1] is not None
+    assert y1.chunks[2] is not None
+    assert y1.chunks[3] is not None
+    np.testing.assert_allclose(0, y2.chunks[0])
+    np.testing.assert_array_equal(y1.chunks[1], y2.chunks[1])
+    np.testing.assert_array_equal(y1.chunks[2], y2.chunks[2])
+    np.testing.assert_array_equal(y1.chunks[3], y2.chunks[3])
 
 
 def test_slice_by_mul():
@@ -202,7 +202,7 @@ def test_slice_by_mul():
     y = x.slice_by_mul[:0]
     assert y.irreps == ""
     assert y.array.shape == (0,)
-    assert len(y.list) == 0
+    assert len(y.chunks) == 0
 
 
 def test_norm():

--- a/e3nn_jax/_src/irreps_array_test.py
+++ b/e3nn_jax/_src/irreps_array_test.py
@@ -17,16 +17,16 @@ def test_empty():
 def test_convert():
     id = e3nn.IrrepsArray.from_list("10x0e + 10x0e", [None, jnp.ones((1, 10, 1))], (1,))
     assert jax.tree_util.tree_map(
-        lambda x: x.shape, id._convert("0x0e + 20x0e + 0x0e")
-    ).list == [None, (1, 20, 1), None]
+        jnp.shape, id._convert("0x0e + 20x0e + 0x0e").chunks
+    ) == [None, (1, 20, 1), None]
     assert jax.tree_util.tree_map(
-        lambda x: x.shape, id._convert("7x0e + 4x0e + 9x0e")
-    ).list == [None, (1, 4, 1), (1, 9, 1)]
+        jnp.shape, id._convert("7x0e + 4x0e + 9x0e").chunks
+    ) == [None, (1, 4, 1), (1, 9, 1)]
 
     id = e3nn.IrrepsArray.from_list("10x0e + 10x1e", [None, jnp.ones((1, 10, 3))], (1,))
     assert jax.tree_util.tree_map(
-        lambda x: x.shape, id._convert("5x0e + 5x0e + 5x1e + 5x1e")
-    ).list == [
+        jnp.shape, id._convert("5x0e + 5x0e + 5x1e + 5x1e").chunks
+    ) == [
         None,
         None,
         (1, 5, 3),

--- a/e3nn_jax/_src/linear.py
+++ b/e3nn_jax/_src/linear.py
@@ -179,8 +179,9 @@ class FunctionalLinear:
             if ins.i_in == -1
             else (
                 None
-                if input.list[ins.i_in] is None
-                else ins.path_weight * jnp.einsum("uw,ui->wi", w, input.list[ins.i_in])
+                if input.chunks[ins.i_in] is None
+                else ins.path_weight
+                * jnp.einsum("uw,ui->wi", w, input.chunks[ins.i_in])
             )
             for ins, w in zip(self.instructions, ws)
         ]

--- a/e3nn_jax/_src/linear.py
+++ b/e3nn_jax/_src/linear.py
@@ -5,6 +5,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+import e3nn_jax as e3nn
 from e3nn_jax import Irreps, IrrepsArray, config
 from e3nn_jax._src.core_tensor_product import _sum_tensors
 from e3nn_jax._src.utils.dtype import get_pytree_dtype
@@ -149,9 +150,7 @@ class FunctionalLinear:
             )
             for i_out, mul_ir_out in enumerate(self.irreps_out)
         ]
-        return IrrepsArray.from_chunks(
-            self.irreps_out, output, output_shape, output_dtype
-        )
+        return e3nn.from_chunks(self.irreps_out, output, output_shape, output_dtype)
 
     def split_weights(self, weights: jnp.ndarray) -> List[jnp.ndarray]:
         ws = []

--- a/e3nn_jax/_src/linear.py
+++ b/e3nn_jax/_src/linear.py
@@ -165,7 +165,7 @@ class FunctionalLinear:
     def __call__(
         self, ws: Union[List[jnp.ndarray], jnp.ndarray], input: IrrepsArray
     ) -> IrrepsArray:
-        input = input._convert(self.irreps_in)
+        input = input.rechunk(self.irreps_in)
         if input.ndim != 1:
             raise ValueError(
                 f"FunctionalLinear does not support broadcasting, input shape is {input.shape}"

--- a/e3nn_jax/_src/linear_flax.py
+++ b/e3nn_jax/_src/linear_flax.py
@@ -167,4 +167,4 @@ class Linear(flax.linen.Module):
 
         if self.channel_out is not None:
             output = output.mul_to_axis(self.channel_out)
-        return output._convert(self.irreps_out)
+        return output.rechunk(self.irreps_out)

--- a/e3nn_jax/_src/linear_flax.py
+++ b/e3nn_jax/_src/linear_flax.py
@@ -104,7 +104,7 @@ class Linear(flax.linen.Module):
                     f"e3nn.flax.Linear: The input irreps ({input.irreps}) do not match the expected irreps ({self.irreps_in})"
                 )
 
-        input = input.remove_nones().regroup()
+        input = input.remove_zero_chunks().regroup()
         output_irreps = e3nn.Irreps(self.irreps_out).simplify()
 
         if self.channel_out is not None:

--- a/e3nn_jax/_src/linear_flax.py
+++ b/e3nn_jax/_src/linear_flax.py
@@ -91,7 +91,7 @@ class Linear(flax.linen.Module):
             input: e3nn.IrrepsArray = input_or_none
         del weights_or_input, input_or_none
 
-        input = e3nn.IrrepsArray.as_irreps_array(input)
+        input = e3nn.as_irreps_array(input)
 
         dtype = get_pytree_dtype(weights, input)
         if dtype.kind == "i":

--- a/e3nn_jax/_src/linear_haiku.py
+++ b/e3nn_jax/_src/linear_haiku.py
@@ -220,4 +220,4 @@ class Linear(hk.Module):
 
         if self.channel_out is not None:
             output = output.mul_to_axis(self.channel_out)
-        return output._convert(self.irreps_out)
+        return output.rechunk(self.irreps_out)

--- a/e3nn_jax/_src/linear_haiku.py
+++ b/e3nn_jax/_src/linear_haiku.py
@@ -149,7 +149,7 @@ class Linear(hk.Module):
             input: e3nn.IrrepsArray = input_or_none
         del weights_or_input, input_or_none
 
-        input = e3nn.IrrepsArray.as_irreps_array(input)
+        input = e3nn.as_irreps_array(input)
 
         dtype = get_pytree_dtype(weights, input)
         if dtype.kind == "i":

--- a/e3nn_jax/_src/linear_haiku.py
+++ b/e3nn_jax/_src/linear_haiku.py
@@ -162,7 +162,7 @@ class Linear(hk.Module):
                     f"e3nn.haiku.Linear: The input irreps ({input.irreps}) do not match the expected irreps ({self.irreps_in})"
                 )
 
-        input = input.remove_nones().regroup()
+        input = input.remove_zero_chunks().regroup()
         output_irreps = self.irreps_out.simplify()
 
         if self.channel_out is not None:

--- a/e3nn_jax/_src/linear_haiku_test.py
+++ b/e3nn_jax/_src/linear_haiku_test.py
@@ -38,7 +38,7 @@ class SlowLinear:
         self.irreps_out = irreps_out
 
     def __call__(self, ws, x):
-        ones = e3nn.IrrepsArray.ones("0e", ())
+        ones = e3nn.IrrepsArray("0e", jnp.array([1.0]))
         return self.tp.left_right(ws, x, ones)
 
 

--- a/e3nn_jax/_src/reduced_tensor_product.py
+++ b/e3nn_jax/_src/reduced_tensor_product.py
@@ -601,7 +601,7 @@ def reduce_basis_product(
                 new_irreps.append((mul1 * mul2, ir))
                 new_list.append(x)
 
-    new = e3nn.IrrepsArray.from_list(
+    new = e3nn.from_chunks(
         new_irreps,
         new_list,
         np.broadcast_shapes(basis1.shape[:-1], basis2.shape[:-1]),
@@ -653,7 +653,7 @@ def constrain_rotation_basis_by_permutation_basis(
         new_irreps.append((len(P), ir))
         new_list.append(round_fn(np.einsum("vu,...ui->...vi", P, rot_basis)))
 
-    return e3nn.IrrepsArray.from_list(
+    return e3nn.from_chunks(
         new_irreps, new_list, rotation_basis.shape[:-1], np.float64, backend=np
     )
 

--- a/e3nn_jax/_src/reduced_tensor_product.py
+++ b/e3nn_jax/_src/reduced_tensor_product.py
@@ -588,8 +588,8 @@ def reduce_basis_product(
     new_irreps: List[Tuple[int, e3nn.Irrep]] = []
     new_list = []
 
-    for (mul1, ir1), x1 in zip(basis1.irreps, basis1.list):
-        for (mul2, ir2), x2 in zip(basis2.irreps, basis2.list):
+    for (mul1, ir1), x1 in zip(basis1.irreps, basis1.chunks):
+        for (mul2, ir2), x2 in zip(basis2.irreps, basis2.chunks):
             for ir in ir1 * ir2:
                 if filter_ir_out is not None and ir not in filter_ir_out:
                     continue
@@ -639,7 +639,7 @@ def constrain_rotation_basis_by_permutation_basis(
 
     for ir in sorted({ir for mul, ir in rotation_basis.irreps}):
         idx = [i for i, (mul, ir_) in enumerate(rotation_basis.irreps) if ir == ir_]
-        rot_basis = np.concatenate([rotation_basis.list[i] for i in idx], axis=-2)
+        rot_basis = np.concatenate([rotation_basis.chunks[i] for i in idx], axis=-2)
         mul = rot_basis.shape[-2]
         R = rot_basis[..., 0]
         R = np.reshape(R, (-1, mul)).T  # (mul, dim)

--- a/e3nn_jax/_src/scatter.py
+++ b/e3nn_jax/_src/scatter.py
@@ -178,34 +178,6 @@ def index_add(
     out_dim: int = None,
     map_back: bool = False,
 ) -> Union[jnp.ndarray, e3nn.IrrepsArray]:
-    r"""Perform the operation.
-
-    ```
-    out = zeros(out_dim, ...)
-    out[indices] += input
-    ```
-
-    if ``map_back`` is ``True``, then the output is mapped back to the input position.
-
-    ```
-    return out[indices]
-    ```
-
-    Args:
-        indices (`jax.numpy.ndarray`): array of indices
-        input (`jax.numpy.ndarray` or `IrrepsArray`): array of data
-        out_dim (int): size of the output
-        map_back (bool): whether to map back to the input position
-
-    Returns:
-        `jax.numpy.ndarray` or ``IrrepsArray``: output
-
-    Examples:
-       >>> i = jnp.array([0, 2, 2, 0])
-       >>> x = jnp.array([1.0, 2.0, 3.0, -10.0])
-       >>> index_add(i, x, out_dim=4)
-       Array([-9.,  0.,  5.,  0.], dtype=float32)
-    """
     warnings.warn(
         "e3nn.index_add is deprecated, use e3nn.scatter_sum instead", DeprecationWarning
     )

--- a/e3nn_jax/_src/symmetric_tensor_product_haiku.py
+++ b/e3nn_jax/_src/symmetric_tensor_product_haiku.py
@@ -93,7 +93,7 @@ class SymmetricTensorProduct(hk.Module):
                 #       out
 
                 if order in self.orders:
-                    for (mul, ir_out), u in zip(U.irreps, U.list):
+                    for (mul, ir_out), u in zip(U.irreps, U.chunks):
                         # u: ndarray [(irreps_x.dim)^order, multiplicity, ir_out.dim]
                         u = (
                             u / u.shape[-2]

--- a/e3nn_jax/_src/symmetric_tensor_product_haiku.py
+++ b/e3nn_jax/_src/symmetric_tensor_product_haiku.py
@@ -134,7 +134,7 @@ class SymmetricTensorProduct(hk.Module):
 
             # out[irrep_out] : [num_channel, ir_out.dim]
             irreps_out = e3nn.Irreps(sorted(out.keys()))
-            return e3nn.IrrepsArray.from_list(
+            return e3nn.from_chunks(
                 irreps_out,
                 [out[ir][:, None, :] for (_, ir) in irreps_out],
                 (x.shape[0],),

--- a/e3nn_jax/_src/symmetric_tensor_product_haiku_test.py
+++ b/e3nn_jax/_src/symmetric_tensor_product_haiku_test.py
@@ -15,5 +15,5 @@ def test_normalization():
     w = jax.jit(model.init)(jax.random.PRNGKey(1), x)
     y = jax.jit(model.apply)(w, x)
 
-    for (mul, ir), e in zip(y.irreps, y.list):
+    for (mul, ir), e in zip(y.irreps, y.chunks):
         assert 0.5 < float(jnp.mean(e**2)) < 6.5

--- a/e3nn_jax/_src/tensor_product_with_spherical_harmonics.py
+++ b/e3nn_jax/_src/tensor_product_with_spherical_harmonics.py
@@ -87,9 +87,9 @@ def impl(
     irreps_out = []
     outputs = []
 
-    for (mul, irx), x in zip(input.irreps, input.list):
+    for (mul, irx), x in zip(input.irreps, input.chunks):
         assert x.shape == (mul, irx.dim)
-        for (_, iry), y in zip(shs.irreps, shs.list):
+        for (_, iry), y in zip(shs.irreps, shs.chunks):
             assert y.shape == (1, iry.dim)
 
             # Verify that the spherical harmonics have a specific form

--- a/e3nn_jax/_src/tensor_product_with_spherical_harmonics.py
+++ b/e3nn_jax/_src/tensor_product_with_spherical_harmonics.py
@@ -34,7 +34,7 @@ def tensor_product_with_spherical_harmonics(
         >>> assert output1.irreps == output2.irreps
         >>> assert jnp.allclose(output1.array, output2.array, atol=1e-6)
     """
-    input = e3nn.IrrepsArray.as_irreps_array(input)
+    input = e3nn.as_irreps_array(input)
 
     if not (vector.irreps == "1o" or vector.irreps == "1e"):
         raise ValueError(
@@ -135,7 +135,7 @@ def impl(
 
                 outputs.append(out)
 
-    out = e3nn.IrrepsArray.from_list(irreps_out, outputs, (), x.dtype)
+    out = e3nn.from_chunks(irreps_out, outputs, (), x.dtype)
     out = out.regroup()  # <-- ops
     out = out.transform_by_angles(alpha, beta, 0.0)  # <-- ops
 

--- a/e3nn_jax/_src/tensor_products.py
+++ b/e3nn_jax/_src/tensor_products.py
@@ -3,9 +3,11 @@ from typing import List, Optional
 
 import jax
 import jax.numpy as jnp
+
+import e3nn_jax as e3nn
 from e3nn_jax import FunctionalTensorProduct, Irrep, Irreps, IrrepsArray, config
-from e3nn_jax._src.utils.decorators import overload_for_irreps_without_array
 from e3nn_jax._src.basic import _align_two_irreps_arrays
+from e3nn_jax._src.utils.decorators import overload_for_irreps_without_array
 
 
 def naive_broadcast_decorator(func):
@@ -69,8 +71,8 @@ def tensor_product(
         >>> e3nn.tensor_product("2x1e + 2e", "2e")
         1x0e+3x1e+3x2e+3x3e+1x4e
     """
-    input1 = IrrepsArray.as_irreps_array(input1)
-    input2 = IrrepsArray.as_irreps_array(input2)
+    input1 = e3nn.as_irreps_array(input1)
+    input2 = e3nn.as_irreps_array(input2)
 
     if regroup_output:
         input1 = input1.regroup()
@@ -153,8 +155,8 @@ def elementwise_tensor_product(
         >>> e3nn.elementwise_tensor_product(x, y)
         1x1e+1x0o+1x1e [ 0.  0.  0.  3.  8. 12. 16.]
     """
-    input1 = IrrepsArray.as_irreps_array(input1)
-    input2 = IrrepsArray.as_irreps_array(input2)
+    input1 = e3nn.as_irreps_array(input1)
+    input2 = e3nn.as_irreps_array(input2)
 
     if filter_ir_out is not None:
         filter_ir_out = [Irrep(ir) for ir in filter_ir_out]
@@ -223,7 +225,7 @@ def tensor_square(
         >>> e3nn.tensor_square(x, normalized_input=True)
         2x0e+1x1o+1x2e [100.    14.    17.32  34.64  51.96  11.62   7.75  -2.24  23.24  15.49]
     """
-    input = IrrepsArray.as_irreps_array(input)
+    input = e3nn.as_irreps_array(input)
 
     if regroup_output:
         input = input.regroup()

--- a/e3nn_jax/_src/utils/decorators.py
+++ b/e3nn_jax/_src/utils/decorators.py
@@ -31,13 +31,13 @@ def overload_for_irreps_without_array(
                 # assume arguments are Irreps (not IrrepsArray)
 
                 converted_args = {
-                    i: IrrepsArray.ones(a, shape)
+                    i: IrrepsArray.zeros(a, shape)
                     for i, a in enumerate(args)
                     if i in argnums
                 }
                 converted_args.update(
                     {
-                        k: IrrepsArray.ones(v, shape)
+                        k: IrrepsArray.zeros(v, shape)
                         for k, v in kwargs.items()
                         if k in argnames
                     }

--- a/e3nn_jax/_src/utils/decorators.py
+++ b/e3nn_jax/_src/utils/decorators.py
@@ -2,7 +2,7 @@ import inspect
 from functools import wraps
 
 import jax
-from e3nn_jax import Irreps, IrrepsArray
+import e3nn_jax as e3nn
 
 
 def overload_for_irreps_without_array(
@@ -27,17 +27,15 @@ def overload_for_irreps_without_array(
                 kwargs[k] for k in argnames if k in kwargs
             ]
 
-            if any(isinstance(arg, (Irreps, str)) for arg in concerned_args):
+            if any(isinstance(arg, (e3nn.Irreps, str)) for arg in concerned_args):
                 # assume arguments are Irreps (not IrrepsArray)
 
                 converted_args = {
-                    i: IrrepsArray.zeros(a, shape)
-                    for i, a in enumerate(args)
-                    if i in argnums
+                    i: e3nn.zeros(a, shape) for i, a in enumerate(args) if i in argnums
                 }
                 converted_args.update(
                     {
-                        k: IrrepsArray.zeros(v, shape)
+                        k: e3nn.zeros(v, shape)
                         for k, v in kwargs.items()
                         if k in argnames
                     }
@@ -50,11 +48,12 @@ def overload_for_irreps_without_array(
 
                 output = jax.eval_shape(fn, converted_args)
 
-                if isinstance(output, IrrepsArray):
+                if isinstance(output, e3nn.IrrepsArray):
                     return output.irreps
                 if isinstance(output, tuple):
                     return tuple(
-                        o.irreps if isinstance(o, IrrepsArray) else o for o in output
+                        o.irreps if isinstance(o, e3nn.IrrepsArray) else o
+                        for o in output
                     )
                 raise TypeError(
                     f"{func.__name__} returned {type(output)} which is not supported by `overload_irrep_no_data`."

--- a/e3nn_jax/_src/utils/test.py
+++ b/e3nn_jax/_src/utils/test.py
@@ -33,7 +33,7 @@ def equivariance_test(
     """
     args = [e3nn.Irreps(arg) if isinstance(arg, str) else arg for arg in args]
     args = [
-        e3nn.IrrepsArray.as_irreps_array(arg) if isinstance(arg, jnp.ndarray) else arg
+        e3nn.as_irreps_array(arg) if isinstance(arg, jnp.ndarray) else arg
         for arg in args
     ]
 

--- a/e3nn_jax/experimental/linear_shtp.py
+++ b/e3nn_jax/experimental/linear_shtp.py
@@ -79,7 +79,7 @@ class LinearSHTP(flax.linen.Module):
             else:
                 mulz = None
 
-            for (ix, (mulx, irx)), x in zip(enumerate(input.irreps), input.list):
+            for (ix, (mulx, irx)), x in zip(enumerate(input.irreps), input.chunks):
                 if x is None:
                     continue
 
@@ -205,7 +205,7 @@ def shtp(
     outputs = []
 
     for irz in filter_irreps_out:
-        for (mulx, irx), x in zip(input.irreps, input.list):
+        for (mulx, irx), x in zip(input.irreps, input.chunks):
             if x is None:
                 continue
 

--- a/e3nn_jax/experimental/linear_shtp.py
+++ b/e3nn_jax/experimental/linear_shtp.py
@@ -152,7 +152,7 @@ class LinearSHTP(flax.linen.Module):
                 irreps_out_.append((z.shape[0], irz))
                 outputs.append(z)
 
-        out = e3nn.IrrepsArray.from_list(irreps_out_, outputs, (), input.dtype)
+        out = e3nn.from_chunks(irreps_out_, outputs, (), input.dtype)
         out = out.regroup()
 
         # Rotate back
@@ -244,7 +244,7 @@ def shtp(
                 irreps_out.append((z.shape[0], irz))
                 outputs.append(z)
 
-    out = e3nn.IrrepsArray.from_list(irreps_out, outputs, (), x.dtype)
+    out = e3nn.from_chunks(irreps_out, outputs, (), x.dtype)
     out = out.regroup()
 
     # Rotate back

--- a/e3nn_jax/experimental/point_convolution.py
+++ b/e3nn_jax/experimental/point_convolution.py
@@ -101,9 +101,7 @@ def _call(
 
     messages = messages * mix  # [n_edges, irreps]
 
-    zeros = e3nn.IrrepsArray.zeros(
-        messages.irreps, node_feats.shape[:1], messages.dtype
-    )
+    zeros = e3nn.zeros(messages.irreps, node_feats.shape[:1], messages.dtype)
     node_feats = zeros.at[receivers].add(messages)  # [n_nodes, irreps]
 
     node_feats = node_feats / jnp.sqrt(self.avg_num_neighbors)

--- a/e3nn_jax/experimental/point_convolution_test.py
+++ b/e3nn_jax/experimental/point_convolution_test.py
@@ -27,7 +27,7 @@ def test_point_convolution(keys):
             lambda r: radial_basis(r, cutoff, 8),
             avg_num_neighbors=2.0,
             mlp_neurons=[64],
-        )(positions, features, senders, receivers)
+        )(positions, features, senders, receivers).remove_zero_chunks()
 
     model_init = jax.jit(model.init)
     model_apply = jax.jit(model.apply)
@@ -49,8 +49,7 @@ def test_point_convolution(keys):
     out = model_apply(w, pos, feat, src, dst)
 
     assert out.shape[:-1] == feat.shape[:-1]
-    assert out.irreps == e3nn.Irreps("8x0e + 8x0o + 5e")
-    assert out.list[2] is None
+    assert out.irreps == e3nn.Irreps("8x0e")
 
     assert_equivariant(
         lambda pos, x: model_apply(w, pos, x, src, dst),

--- a/e3nn_jax/experimental/voxel_convolution.py
+++ b/e3nn_jax/experimental/voxel_convolution.py
@@ -274,7 +274,7 @@ def _call(
         i = 0
         for mul_ir in e3nn.Irreps(self.irreps_out):
             if i < len(irreps_out) and irreps_out[i] == mul_ir:
-                list.append(output.list[i])
+                list.append(output.chunks[i])
                 i += 1
             else:
                 list.append(None)

--- a/e3nn_jax/experimental/voxel_convolution.py
+++ b/e3nn_jax/experimental/voxel_convolution.py
@@ -244,7 +244,7 @@ def _call(
     if not isinstance(input, e3nn.IrrepsArray):
         raise ValueError("Convolution: input should be of type IrrepsArray")
 
-    input = input.remove_nones().simplify()
+    input = input.remove_zero_chunks().simplify()
 
     irreps_out = e3nn.Irreps(
         [

--- a/e3nn_jax/experimental/voxel_convolution.py
+++ b/e3nn_jax/experimental/voxel_convolution.py
@@ -278,7 +278,7 @@ def _call(
                 i += 1
             else:
                 list.append(None)
-        output = e3nn.IrrepsArray.from_list(
+        output = e3nn.from_chunks(
             self.irreps_out, list, output.shape[:-1], output.dtype
         )
 

--- a/e3nn_jax/experimental/voxel_convolution_test.py
+++ b/e3nn_jax/experimental/voxel_convolution_test.py
@@ -17,8 +17,8 @@ def test_convolution(keys):
         irreps_out=irreps_out,
         irreps_sh=irreps_sh,
         diameter=3.9,
-        num_radial_basis={0: 3, 1: 2, 2: 1},
-        relative_starts={0: 0.0, 1: 0.0, 2: 0.5},
+        num_radial_basis=2,
+        relative_starts=0.0,
         steps=(1.0, 1.0, 1.0),
     )
 

--- a/examples/tensor_product_benchmark.py
+++ b/examples/tensor_product_benchmark.py
@@ -109,7 +109,7 @@ def main():
     f = tp.apply
     if args.lists:
         f_1 = f
-        f = lambda w, x1, x2: f_1(w, x1, x2).list
+        f = lambda w, x1, x2: f_1(w, x1, x2).chunks
     else:
         f_1 = f
         f = lambda w, x1, x2: f_1(w, x1, x2).array

--- a/examples/tetris_point.py
+++ b/examples/tetris_point.py
@@ -49,7 +49,7 @@ class Model(flax.linen.Module):
     @flax.linen.compact
     def __call__(self, pos, edge_src, edge_dst):
         pos = e3nn.IrrepsArray("1o", pos)
-        node_feat = e3nn.IrrepsArray.ones("0e", (pos.shape[0],), pos.dtype)
+        node_feat = e3nn.IrrepsArray("0e", jnp.ones((pos.shape[0], 1), pos.dtype))
 
         kw = dict(
             radial_basis=lambda r: jnp.ones_like(r)[:, None],

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,4 +31,4 @@ install_requires =
     sympy
     numpy
     tqdm
-    attr
+    attrs

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,4 @@ install_requires =
     sympy
     numpy
     tqdm
+    attr


### PR DESCRIPTION
- IrrepsArray only contains `.array` as `jax.Array` attributes.
- It is now a frozen class.
- It now has `.zero_flags` attribute, a tuple of bools that are used to construct `.chunks` (new name for `.list`).
- `.zero_flags` are dropped by pytree encode/decode mechanism to avoid any mistake like:

```python
tree_map(lambda x: x + 1.0, irreps_array)
```