### PR TITLE
Caching CG coeffs

### DIFF
--- a/e3nn_jax/_src/tensor_products.py
+++ b/e3nn_jax/_src/tensor_products.py
@@ -36,6 +36,14 @@ def _validate_filter_ir_out(filter_ir_out):
         filter_ir_out = [e3nn.Irrep(ir) for ir in filter_ir_out]
     return filter_ir_out
 
+# Cache CG coefficients outside of function 
+cg_coeffs = {}
+
+def get_cg(l1, l2, l3):
+  key = (l1, l2, l3)
+  if key not in cg_coeffs:
+    cg_coeffs[key] = e3nn.clebsch_gordan(l1, l2, l3) 
+  return cg_coeffs[key]
 
 @overload_for_irreps_without_array((0, 1))
 def tensor_product(
@@ -105,7 +113,7 @@ def tensor_product(
                 irreps_out.append((mul_1 * mul_2, ir_out))
 
                 if x1 is not None and x2 is not None:
-                    cg = e3nn.clebsch_gordan(ir_1.l, ir_2.l, ir_out.l)
+                    cg = get_cg(ir_1.l, ir_2.l, ir_out.l)
 
                     if irrep_normalization == "component":
                         cg = cg * jnp.sqrt(ir_out.dim)


### PR DESCRIPTION
Caching CG coefs during runtime

Experiment: https://gist.github.com/mitkotak/90ccfcc39da8c4592c130b9bf09a3c00 on NVIDIA TITAN V

Speedup: 
<img width="726" alt="Screenshot 2023-08-04 at 10 32 28 PM" src="https://github.com/e3nn/e3nn-jax/assets/53411468/492f0378-e971-4f01-8994-8c95aad8af1a">