### PR TITLE
chore: migrate style config to `pyproject.toml`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-source=e3nn_jax
-
-[report]
-exclude_lines =
-    pragma: no cover
-    raise
-    except

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-ignore = E741, E203, W503, E731, E721
-max-line-length = 127
-max-complexity = 64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install flake8
       run: |
-        pip install flake8
+        pip install flake8 Flake8-pyproject
     - name: Lint with flake8
       run: |
         flake8 . --count --show-source --statistics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,18 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.coverage.run]
+source = ["e3nn_jax"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "pragma: no cover",
+  "raise",
+  "except"
+]
+
+[tool.flake8]
+ignore = ["E741", "E203", "W503", "E731", "E721"]
+max-line-length = 127
+max-complexity = 64


### PR DESCRIPTION
This PR aims to minimize the number of configuration files for a overall minimal project structure and better contributor onboarding experience. Changes made by this PR can be summarized as follows:

* Add [Flake8-pyproject](https://pypi.org/project/Flake8-pyproject/) as an additional dependency in the Github Actions workflow to allow for `flake8` configuration from within `pyproject.toml`.
* Migrate `coverage` configuration to `pyproject.toml`.

---

References:

* A Similar PR was accepted to pytorch-geometric viz. https://github.com/pyg-team/pytorch_geometric/pull/7204


Request for Review: @mariogeiger 