### PR TITLE
Fix python 3.9 compatibility

### DIFF
--- a/e3nn_jax/_src/s2grid.py
+++ b/e3nn_jax/_src/s2grid.py
@@ -1085,8 +1085,8 @@ def _to_s2grid_s2fft(
     res_alpha: int,
     *,
     normalization: str = "integral",
-    p_val: int | None = None,
-    p_arg: int | None = None,
+    p_val: Optional[int] = None,
+    p_arg: Optional[int] = None,
 ) -> SphericalSignal:
     """An S2FFT powered version of e3nn_jax.to_s2grid."""
     import s2fft


### PR DESCRIPTION
From the `pyproject.toml` file it looks that 3.9 is the minimum python version supported, but some of the code in #47 introduced syntax that's only supported in python `>=3.10`.