### PR TITLE
Add equinox modules to docs

### DIFF
--- a/docs/api/equinox.rst
+++ b/docs/api/equinox.rst
@@ -1,0 +1,5 @@
+Equinox Modules
+===============
+
+.. autoclass:: e3nn_jax.equinox.Linear
+    :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -13,6 +13,7 @@ API
     radial
     haiku
     flax
+    equinox
     s2
     extra
     utils

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,3 +13,4 @@ jraph
 nequip_jax @ git+https://github.com/mariogeiger/nequip-jax@1.1.0
 flax
 dm-haiku
+equinox

--- a/e3nn_jax/_src/linear_equinox.py
+++ b/e3nn_jax/_src/linear_equinox.py
@@ -28,7 +28,7 @@ def _get_gradient_normalization(
 
 
 class Linear(eqx.Module):
-    r"""Equivariant Linear Flax module
+    r"""Equivariant Linear Equinox module
 
     Args:
         irreps_out (`Irreps`): output representations, if allowed bu Schur's lemma.


### PR DESCRIPTION
Add equinox modules to docs (thanks to @ameya98 for the nice existing docstring). See deployed page at https://e3nn-jax--97.org.readthedocs.build/en/97/api/equinox.html