### PR TITLE
Fix concretization error with normalize_function

### DIFF
--- a/e3nn_jax/_src/activation.py
+++ b/e3nn_jax/_src/activation.py
@@ -58,16 +58,12 @@ def normalize_function(phi: Callable[[float], float]) -> Callable[[float], float
         # x = jax.random.normal(k, (1_000_000,))
         x = normalspace(1_000_001)
         c = jnp.mean(phi(x) ** 2) ** 0.5
-        c = c.item()
+        scale = jnp.where(jnp.allclose(c, 1.0), 1.0, 1.0 / c)
 
-        if jnp.allclose(c, 1.0):
-            return phi
-        else:
+        def rho(x):
+            return phi(x) * scale
 
-            def rho(x):
-                return phi(x) / c
-
-            return rho
+        return rho
 
 
 def parity_function(phi: Callable[[float], float]) -> int:


### PR DESCRIPTION
`e3nn_jax.activation.normalize_function` currently prevents shard map from working due to the `.item()` call. Reproducer:

```python
import os
os.environ.setdefault("JAX_PLATFORMS", "cpu")
os.environ["XLA_FLAGS"] = " --xla_force_host_platform_device_count=2"

from functools import partial
import jax, jax.numpy as jnp
from jax import lax, pmap
from e3nn_jax._src.activation import normalize_function

mesh = jax.sharding.Mesh(jax.devices()[:2], ("i",))
P = jax.sharding.PartitionSpec


def foo(x):
    act = normalize_function(jax.nn.silu)
    return jnp.sum(act(x))

# pmap: works
@partial(pmap, axis_name="i")
def pmap_ok(x):
    return foo(lax.all_gather(x, "i").reshape(-1))

print("pmap:", pmap_ok(jnp.ones((2, 4))))

# shard_map: fails
@partial(jax.shard_map, mesh=mesh, in_specs=(P("i"),), out_specs=P(), check_vma=False)
def shard_map_fail(x):
    return foo(lax.all_gather(x, "i").reshape(-1))

try:
    print("shard_map:", shard_map_fail(jax.device_put(jnp.ones((2, 4)), jax.sharding.NamedSharding(mesh, P("i")))))
except jax.errors.ConcretizationTypeError as e:
    print(f"shard_map FAILS: {type(e).__name__}: {str(e)[:120]}...")
 ```
 
 This change fixes.